### PR TITLE
Fix bug in weekly reset function

### DIFF
--- a/Helper.lua
+++ b/Helper.lua
@@ -356,9 +356,8 @@ end
 function addon:getWeeklyLockoutDate()
     local secondsInDay      = 24 * 60 * 60;
     local serverResetDay    = MapRegionReset[ GetCurrentRegion() ];
-    local daysLefToReset    = weekdayRemap[ serverResetDay ][ date( "*t", currentServerTime ).wday ];
-
     local currentServerTime = GetServerTime();
+    local daysLefToReset    = weekdayRemap[ serverResetDay ][ date( "*t", currentServerTime ).wday ];
     local weeklyResetTime   = self:getDailyLockoutDate();
 
     -- handle reset on day of reset (before vs after server reset)


### PR DESCRIPTION
fix critical bug identified in #63 and #82.

currentServerTime was in use before we set it which could result in the improper date being returned from the weekly lockout.  because it is called so much it was basing it off prior values of the variable and thus mostly working.

close #63
close #82